### PR TITLE
fix: 修正 OpenAI 拼寫錯誤、介面字串安全性，並為若干字串補上國際化程式碼

### DIFF
--- a/trunk/muki-ai-summary.php
+++ b/trunk/muki-ai-summary.php
@@ -23,7 +23,7 @@ define('MUKI_AI_SUMMARY_VERSION', '1.0.4');
 
 // Setup menu
 function muki_ai_summary_menu() {
-  add_options_page('Muki AI Summary Settings', 'Muki AI Summary', 'manage_options', 'muki-ai-summary', 'muki_ai_summary_options_page');
+  add_options_page(__( 'Muki AI Summary Settings', 'muki-ai-summary' ), 'Muki AI Summary', 'manage_options', 'muki-ai-summary', 'muki_ai_summary_options_page');
 }
 add_action('admin_menu', 'muki_ai_summary_menu');
 
@@ -44,7 +44,7 @@ function muki_ai_summary_options_page() {
   }
   ?>
   <div class="wrap">
-    <h1><?php _e('Muki AI Summary Settings', 'muki-ai-summary'); ?></h1>
+    <h1><?php esc_html_e('Muki AI Summary Settings', 'muki-ai-summary'); ?></h1>
     <form method="post" action="options.php">
       <?php
       settings_fields('muki_ai_summary_options');
@@ -54,17 +54,17 @@ function muki_ai_summary_options_page() {
     </form>
     <form method="post" action="">
       <?php wp_nonce_field('muki_ai_clean_summaries_nonce'); ?>
-      <input type="submit" name="muki_ai_clean_summaries" class="button button-secondary" value="Clear All AI Summary Data" onclick="return confirm('Are you sure you want to clear all AI summary data? This action cannot be undone.');">
+      <input type="submit" name="muki_ai_clean_summaries" class="button button-secondary" value="<?php esc_attr_e( 'Clear All AI Summary Data', 'muki-ai-summary' ); ?>" onclick="return confirm('<?php esc_attr_e( 'Are you sure you want to clear all AI summary data? This action cannot be undone.', 'muki-ai-summary' ); ?>');">
     </form>
     <div class="muki-ai-summary-usage">
-      <h2><?php _e('Using AI-generated summaries in themes', 'muki-ai-summary'); ?></h2>
-      <p><?php _e('You can use the following function in your theme to display AI-generated summaries:', 'muki-ai-summary'); ?></p>
+      <h2><?php esc_html_e('Using AI-generated summaries in themes', 'muki-ai-summary'); ?></h2>
+      <p><?php esc_html_e('You can use the following function in your theme to display AI-generated summaries:', 'muki-ai-summary'); ?></p>
       <pre><code>if (function_exists('muki_ai_get_summary')) {
             echo muki_ai_get_summary(get_the_ID());
           }</code></pre>
-      <p><?php _e('This function will return the AI-generated summary for the current post. If the summary doesn\'t exist, it will return null.', 'muki-ai-summary'); ?></p>
-      <h2><?php _e('Customizing AI Summary Style', 'muki-ai-summary'); ?></h2>
-      <p><?php _e('AI summaries use the class <code>muki_ai_summary--excerpt</code> for styling. You can customize the style in your theme\'s style.css file:', 'muki-ai-summary'); ?></p>
+      <p><?php esc_html_e('This function will return the AI-generated summary for the current post. If the summary doesn\'t exist, it will return null.', 'muki-ai-summary'); ?></p>
+      <h2><?php esc_html_e('Customizing AI Summary Style', 'muki-ai-summary'); ?></h2>
+      <p><?php printf(esc_html__( 'AI summaries use the class %1$smuki_ai_summary--excerpt%2$s for styling. You can customize the style in your theme\'s style.css file:', 'muki-ai-summary' ),'<code>','</code>'); ?></p>
       <pre><code>.muki_ai_summary--excerpt {
             /* Add your custom styles here */
           }</code></pre>
@@ -85,7 +85,7 @@ function muki_ai_summary_register_settings() {
 
   add_settings_section(
     'muki_ai_summary_main',
-    'Main Settings',
+    __('Main Settings', 'muki-ai-summary'),
     'muki_ai_summary_section_callback',
     'muki-ai-summary'
   );
@@ -172,8 +172,8 @@ function muki_ai_summary_position_callback() {
   $position = get_option('muki_ai_summary_position', 'top');
   ?>
   <select name="muki_ai_summary_position">
-    <option value="top" <?php selected($position, 'top'); ?>><?php _e('Top of the article', 'muki-ai-summary'); ?></option>
-    <option value="bottom" <?php selected($position, 'bottom'); ?>><?php _e('Bottom of the article', 'muki-ai-summary'); ?></option>
+    <option value="top" <?php selected($position, 'top'); ?>><?php esc_html_e('Top of the article', 'muki-ai-summary'); ?></option>
+    <option value="bottom" <?php selected($position, 'bottom'); ?>><?php esc_html_e('Bottom of the article', 'muki-ai-summary'); ?></option>
   </select>
   <?php
 }
@@ -187,10 +187,10 @@ function muki_ai_model_callback() {
   $model = get_option('muki_ai_model', 'gpt-3.5-turbo');
   ?>
   <select name="muki_ai_model">
-    <option value="gpt-3.5-turbo" <?php selected($model, 'gpt-3.5-turbo'); ?>><?php _e('GPT-3.5-turbo', 'muki-ai-summary'); ?></option>
-    <option value="gpt-4o" <?php selected($model, 'gpt-4o'); ?>><?php _e('GPT-4', 'muki-ai-summary'); ?></option>
+    <option value="gpt-3.5-turbo" <?php selected($model, 'gpt-3.5-turbo'); ?>><?php esc_html_e('GPT-3.5-turbo', 'muki-ai-summary'); ?></option>
+    <option value="gpt-4o" <?php selected($model, 'gpt-4o'); ?>><?php esc_html_e('GPT-4', 'muki-ai-summary'); ?></option>
   </select>
-  <p class="description"><?php _e('Choose the OpenAI model to use.', 'muki-ai-summary'); ?></p>
+  <p class="description"><?php esc_html_e('Choose the OpenAI model to use.', 'muki-ai-summary'); ?></p>
   <?php
 }
 
@@ -198,10 +198,10 @@ function muki_ai_summary_language_callback() {
   $language = get_option('muki_ai_summary_language', 'zh-TW');
   ?>
   <select name="muki_ai_summary_language">
-    <option value="zh-TW" <?php selected($language, 'zh-TW'); ?>><?php _e('Traditional Chinese', 'muki-ai-summary'); ?></option>
-    <option value="zh-CN" <?php selected($language, 'zh-CN'); ?>><?php _e('Simplified Chinese', 'muki-ai-summary'); ?></option>
-    <option value="en" <?php selected($language, 'en'); ?>><?php _e('English', 'muki-ai-summary'); ?></option>
-    <option value="jp" <?php selected($language, 'jp'); ?>><?php _e('Japanese', 'muki-ai-summary'); ?></option>
+    <option value="zh-TW" <?php selected($language, 'zh-TW'); ?>><?php esc_html_e('Traditional Chinese', 'muki-ai-summary'); ?></option>
+    <option value="zh-CN" <?php selected($language, 'zh-CN'); ?>><?php esc_html_e('Simplified Chinese', 'muki-ai-summary'); ?></option>
+    <option value="en" <?php selected($language, 'en'); ?>><?php esc_html_e('English', 'muki-ai-summary'); ?></option>
+    <option value="jp" <?php selected($language, 'jp'); ?>><?php esc_html_e('Japanese', 'muki-ai-summary'); ?></option>
   </select>
   <?php
 }
@@ -221,9 +221,9 @@ function muki_ai_summary_auto_generate_callback() {
   ?>
   <label>
     <input type="checkbox" name="muki_ai_summary_auto_generate[single]" value="1" <?php checked(isset($options['single']) && $options['single'], true); ?>>
-    <?php _e('Single post page', 'muki-ai-summary'); ?>
+    <?php esc_html_e('Single post page', 'muki-ai-summary'); ?>
   </label>
-  <p class="description"><?php _e('Choose where to auto-generate AI summaries (if not already generated).', 'muki-ai-summary'); ?></p>
+  <p class="description"><?php esc_html_e('Choose where to auto-generate AI summaries (if not already generated).', 'muki-ai-summary'); ?></p>
   <?php
 }
 
@@ -264,7 +264,7 @@ function muki_ai_generate_summary($content, $post_id, $force_regenerate = false)
   $system_message = "You are a professional article summarizer. Create a concise summary in 1-2 paragraphs, separated by a blank line. Ensure the summary is complete and doesn't end abruptly. Avoid using terms like 'the author' or 'this article'. Focus on key points and maintain the original tone.";
 
   if (empty($api_key)) {
-    update_option('muki_ai_last_error', 'OpenAI API key not set');
+    update_option('muki_ai_last_error', __( 'OpenAI API key not set', 'muki-ai-summary' ));
     return false;
   }
 
@@ -371,7 +371,7 @@ function muki_ai_set_cached_summary($post_id, $summary) {
 
 // Add sidebar button
 function muki_ai_summary_meta_box() {
-  add_meta_box('muki-ai-summary', 'Generate AI Summary', 'muki_ai_summary_meta_box_callback', 'post', 'side', 'high');
+  add_meta_box('muki-ai-summary', __( 'Generate AI Summary', 'muki-ai-summary' ), 'muki_ai_summary_meta_box_callback', 'post', 'side', 'high');
 }
 add_action('add_meta_boxes', 'muki_ai_summary_meta_box');
 
@@ -380,10 +380,10 @@ function muki_ai_summary_meta_box_callback($post) {
   wp_nonce_field('muki_ai_summary_nonce', 'muki_ai_summary_nonce');
   $current_summary = get_post_meta($post->ID, 'muki_ai_summary', true);
   ?>
-  <button id="muki-ai-generate-summary" class="button"><?php _e('Generate AI Summary', 'muki-ai-summary'); ?></button>
+  <button id="muki-ai-generate-summary" class="button"><?php esc_html_e('Generate AI Summary', 'muki-ai-summary'); ?></button>
   <div id="muki-ai-summary-result">
     <?php if (!empty($current_summary)): ?>
-      <h4><?php _e('Current AI Summary:', 'muki-ai-summary'); ?></h4>
+      <h4><?php esc_html_e('Current AI Summary:', 'muki-ai-summary'); ?></h4>
       <p><?php echo wp_kses_post($current_summary); ?></p>
     <?php endif; ?>
   </div>

--- a/trunk/readme-zh_TW.txt
+++ b/trunk/readme-zh_TW.txt
@@ -9,11 +9,11 @@ Requires PHP: 7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-使用 Open AI 為您的文章生成摘要。
+使用 OpenAI 為您的文章生成摘要。
 
 == 介紹 ==
 
-Muki AI Summary 串接 Open AI Key，幫助您的自動產生文章摘要。
+Muki AI Summary 串接 OpenAI Key，幫助您的自動產生文章摘要。
 這個工具可以讓您的讀者快速了解文章的主要內容，提高用戶體驗並增加網站的參與度。
 
 主要特點：
@@ -51,7 +51,7 @@ Muki AI Summary 串接 Open AI Key，幫助您的自動產生文章摘要。
 
 = 這個外掛如何工作？ =
 
-Muki AI Summary 使用 Open AI 分析您的文章內容，然後生成一個簡潔而準確的摘要。
+Muki AI Summary 使用 OpenAI 分析您的文章內容，然後生成一個簡潔而準確的摘要。
 
 = 使用這個外掛時，我的內容安全嗎？ =
 

--- a/trunk/readme.txt
+++ b/trunk/readme.txt
@@ -9,11 +9,11 @@ Requires PHP: 7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Generate article summaries using Open AI.
+Generate article summaries using OpenAI.
 
 == Description ==
 
-Muki AI Summary integrates with Open AI Key to help you automatically generate article summaries.
+Muki AI Summary integrates with OpenAI Key to help you automatically generate article summaries.
 This tool allows your readers to quickly understand the main content of the article, improving user experience and increasing website engagement.
 
 Main features:
@@ -51,7 +51,7 @@ Note: Your OpenAI API key and article content are sent directly to OpenAI's serv
 
 = How does this plugin work? =
 
-Muki AI Summary uses Open AI to analyze your article content and then generate a concise and accurate summary.
+Muki AI Summary uses OpenAI to analyze your article content and then generate a concise and accurate summary.
 
 = Is my content secure when using this plugin? =
 


### PR DESCRIPTION
1. 修正 OpenAI 這個服務品牌的拼寫錯誤。
2. 為相關介面字串補上 esc_html 相關函式，避免語言套件產生不必要的安全性問題。這個語言套件可能會產生的安全性漏洞曾有惡意第三方想要使用，這代表還是有可能發生，唯一的方式就是修正撰寫介面字串時使用的函式。如果使用官方的 Plugin Check 檢查，應該會出現相關檢查項目出現的檢查結果。
3. 為沒有國際化程式碼的介面字串補上國際化程式碼。請注意，我沒有完全補完，因為現在美國的學校還在放假，我現在找不到時間完全補完。
4. 可以移除外掛中的台灣漢文語言套件，在系統已經會推送的狀況下，內建語言套件只會讓外掛安裝套件 ZIP 壓縮檔變大而已。
5. JS (區塊編輯器使用) 的介面字串尚未處理，這跟數學一樣，不會就是不會，這部分我完全沒天分。
6. 外掛說明頁的內容已經完全 zh_TW 本地化。